### PR TITLE
feat: :triangular_flag_on_post: allow time interval greater than 1s

### DIFF
--- a/CSharp/FrameRateTask/Exceptions.cs
+++ b/CSharp/FrameRateTask/Exceptions.cs
@@ -29,7 +29,7 @@ namespace Timothy.FrameRateTask
     public class IllegalTimeIntervalException : ArgumentOutOfRangeException
     {
         ///
-        public override string Message => "The time interval should be a positive number and not exceed 1000ms!";
+        public override string Message => "The time interval should be a positive number!";
     }
 
     /// <summary>

--- a/CSharp/FrameRateTask/FrameRateTask.cs
+++ b/CSharp/FrameRateTask/FrameRateTask.cs
@@ -181,7 +181,7 @@ namespace Timothy.FrameRateTask
             {
                 ulong timeExceedCount = 0UL;
                 long lastLoopEndingTickCount, beginTickCount;
-
+                
                 var nextTime = (lastLoopEndingTickCount = beginTickCount = Environment.TickCount64) + timeInterval;
                 var endTime = beginTickCount < long.MaxValue - maxTotalDuration ? beginTickCount + maxTotalDuration : long.MaxValue;
 
@@ -192,11 +192,11 @@ namespace Timothy.FrameRateTask
                 {
                     if (!loopToDo()) break;
 
-                    var nowTime = Environment.TickCount64;
-                    if (nextTime >= nowTime)
+                    var currentTime = Environment.TickCount64;
+                    if (nextTime >= currentTime)
                     {
                         timeExceedCount = 0UL;
-                        Thread.Sleep((int)(nextTime - nowTime));
+                        Thread.Sleep((int)(nextTime - currentTime));
                     }
                     else
                     {
@@ -220,9 +220,11 @@ namespace Timothy.FrameRateTask
                     lastLoopEndingTickCount = nextTime;
                     nextTime += timeInterval;
                     ++loopCnt;
-                    if (Environment.TickCount64 >= nextCntTime)
+
+                    currentTime = Environment.TickCount64;
+                    if (currentTime >= nextCntTime)
                     {
-                        nextCntTime = Environment.TickCount64 + 1000L;
+                        nextCntTime = currentTime + 1000L;
                         FrameRate = loopCnt;
                         loopCnt = 0;
                     }

--- a/CSharp/FrameRateTask/FrameRateTask.cs
+++ b/CSharp/FrameRateTask/FrameRateTask.cs
@@ -171,7 +171,7 @@ namespace Timothy.FrameRateTask
             )
         {
 
-            if (timeInterval <= 0L && timeInterval > 1000L)
+            if (timeInterval <= 0L)
             {
                 throw new IllegalTimeIntervalException();
             }


### PR DESCRIPTION
<!-- Before creating this pull request, check the questions below: -->  
<!-- 在提出这个 pull request 之前，请勾选下面的问题： -->

- [x] 您的代码是否能够编译通过？
- [x] 您是否检查了目前在 [pull requests](https://github.com/Timothy-LiuXuefeng/FrameRateTask/pulls) 中是否有与你的贡献功能相同的更改？
- [x] 您的贡献是否符合[贡献者代码协议](https://github.com/Timothy-LiuXuefeng/FrameRateTask/blob/master/CODE_OF_CONDUCT.md)？

Discriptions of this pull request:

<!-- If you have something to say about this pull request, delete the sentence 'No additional discription.' below and add your description. -->

Cancel the limit that the time interval must be no more than 1s
